### PR TITLE
Move `#endif` in `CFocusRendererGL::RenderEnd(void)`

### DIFF
--- a/xbmc/guilib/GUIFocusPlane.cpp
+++ b/xbmc/guilib/GUIFocusPlane.cpp
@@ -147,7 +147,6 @@ void CFocusRendererGL::RenderEnd(void)
   glBindTexture(GL_TEXTURE_2D, 0);
   glDisable(GL_TEXTURE_2D);
   VerifyGLState();
-#endif
 
   CPoint pos(m_control->GetXPosition(), m_control->GetYPosition());
   g_graphicsContext.SetOrigin(pos.x, pos.y);
@@ -191,6 +190,7 @@ void CFocusRendererGL::RenderEnd(void)
   VerifyGLState();
 
   g_graphicsContext.RestoreOrigin();
+#endif
 }
 
 #endif


### PR DESCRIPTION
I needed this change to get it to build on my Odroid C1+ running Arch Linux ARM. Without the change, compilation failed with ~8 messages saying the OpenGL related symbols, e.g. `glEnable` and `GL_LINE_SMOOTH`, were not declared.

When I checked the macros, I found that `HAS_GL` was undefined and `HAS_GLES` was set to `2`. The file includes all seemed to work, but the missing symbols are indeed not declared in the files that are included for this, i.e. `/usr/include/GLES2/*.h` on my system.

I'm not sure whether this change makes any sense semantically --- however, since most of the other methods don't do anything either, I figured it's probably OK.